### PR TITLE
Fix "kosko migrate -f -" not working

### DIFF
--- a/integration/kosko-migrate/__fixtures__/deployment-and-service.yaml
+++ b/integration/kosko-migrate/__fixtures__/deployment-and-service.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+spec:
+  selector:
+    matchLabels:
+      app: redis
+      role: master
+      tier: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+        tier: backend
+    spec:
+      containers:
+        - name: master
+          image: k8s.gcr.io/redis:e2e
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          ports:
+            - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+    role: master
+    tier: backend
+spec:
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    app: redis
+    role: master
+    tier: backend

--- a/integration/kosko-migrate/__fixtures__/only-deployment.yaml
+++ b/integration/kosko-migrate/__fixtures__/only-deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+spec:
+  selector:
+    matchLabels:
+      app: redis
+      role: master
+      tier: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+        tier: backend
+    spec:
+      containers:
+        - name: master
+          image: k8s.gcr.io/redis:e2e
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          ports:
+            - containerPort: 6379

--- a/integration/kosko-migrate/__tests__/__snapshots__/index.ts.snap
+++ b/integration/kosko-migrate/__tests__/__snapshots__/index.ts.snap
@@ -1,0 +1,260 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`when filename is not given should print the error 1`] = `
+"kosko migrate
+
+Migrate YAML into components
+
+Global Options:
+  --cwd      Path of working directory                   [string] [default: CWD]
+  --silent   Disable log output                       [boolean] [default: false]
+  --help     Show help                                                 [boolean]
+  --version  Show version number                                       [boolean]
+
+Options:
+  --filename, -f  File, directory to migrate                 [string] [required]
+
+Examples:
+  kosko migrate -f path/to/file  Read from the path
+  kosko migrate -f -             Read from stdin
+
+Missing required argument: filename
+"
+`;
+
+exports[`when path is - should print the output 1`] = `
+"\\"use strict\\";
+
+const { Deployment } = require(\\"kubernetes-models/apps/v1/Deployment\\");
+
+const deployment = new Deployment({
+  \\"metadata\\": {
+    \\"name\\": \\"redis-master\\",
+    \\"labels\\": {
+      \\"app\\": \\"redis\\"
+    }
+  },
+  \\"spec\\": {
+    \\"selector\\": {
+      \\"matchLabels\\": {
+        \\"app\\": \\"redis\\",
+        \\"role\\": \\"master\\",
+        \\"tier\\": \\"backend\\"
+      }
+    },
+    \\"replicas\\": 1,
+    \\"template\\": {
+      \\"metadata\\": {
+        \\"labels\\": {
+          \\"app\\": \\"redis\\",
+          \\"role\\": \\"master\\",
+          \\"tier\\": \\"backend\\"
+        }
+      },
+      \\"spec\\": {
+        \\"containers\\": [
+          {
+            \\"name\\": \\"master\\",
+            \\"image\\": \\"k8s.gcr.io/redis:e2e\\",
+            \\"resources\\": {
+              \\"requests\\": {
+                \\"cpu\\": \\"100m\\",
+                \\"memory\\": \\"100Mi\\"
+              }
+            },
+            \\"ports\\": [
+              {
+                \\"containerPort\\": 6379
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+});
+
+module.exports = [deployment];"
+`;
+
+exports[`when path is a directory should print the output 1`] = `
+"\\"use strict\\";
+
+const { Deployment } = require(\\"kubernetes-models/apps/v1/Deployment\\");
+const { Service } = require(\\"kubernetes-models/v1/Service\\");
+
+const deployment = new Deployment({
+  \\"metadata\\": {
+    \\"name\\": \\"redis-master\\",
+    \\"labels\\": {
+      \\"app\\": \\"redis\\"
+    }
+  },
+  \\"spec\\": {
+    \\"selector\\": {
+      \\"matchLabels\\": {
+        \\"app\\": \\"redis\\",
+        \\"role\\": \\"master\\",
+        \\"tier\\": \\"backend\\"
+      }
+    },
+    \\"replicas\\": 1,
+    \\"template\\": {
+      \\"metadata\\": {
+        \\"labels\\": {
+          \\"app\\": \\"redis\\",
+          \\"role\\": \\"master\\",
+          \\"tier\\": \\"backend\\"
+        }
+      },
+      \\"spec\\": {
+        \\"containers\\": [
+          {
+            \\"name\\": \\"master\\",
+            \\"image\\": \\"k8s.gcr.io/redis:e2e\\",
+            \\"resources\\": {
+              \\"requests\\": {
+                \\"cpu\\": \\"100m\\",
+                \\"memory\\": \\"100Mi\\"
+              }
+            },
+            \\"ports\\": [
+              {
+                \\"containerPort\\": 6379
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+});
+
+const service = new Service({
+  \\"metadata\\": {
+    \\"name\\": \\"redis-master\\",
+    \\"labels\\": {
+      \\"app\\": \\"redis\\",
+      \\"role\\": \\"master\\",
+      \\"tier\\": \\"backend\\"
+    }
+  },
+  \\"spec\\": {
+    \\"ports\\": [
+      {
+        \\"port\\": 6379,
+        \\"targetPort\\": 6379
+      }
+    ],
+    \\"selector\\": {
+      \\"app\\": \\"redis\\",
+      \\"role\\": \\"master\\",
+      \\"tier\\": \\"backend\\"
+    }
+  }
+});
+
+const deployment1 = new Deployment({
+  \\"metadata\\": {
+    \\"name\\": \\"redis-master\\",
+    \\"labels\\": {
+      \\"app\\": \\"redis\\"
+    }
+  },
+  \\"spec\\": {
+    \\"selector\\": {
+      \\"matchLabels\\": {
+        \\"app\\": \\"redis\\",
+        \\"role\\": \\"master\\",
+        \\"tier\\": \\"backend\\"
+      }
+    },
+    \\"replicas\\": 1,
+    \\"template\\": {
+      \\"metadata\\": {
+        \\"labels\\": {
+          \\"app\\": \\"redis\\",
+          \\"role\\": \\"master\\",
+          \\"tier\\": \\"backend\\"
+        }
+      },
+      \\"spec\\": {
+        \\"containers\\": [
+          {
+            \\"name\\": \\"master\\",
+            \\"image\\": \\"k8s.gcr.io/redis:e2e\\",
+            \\"resources\\": {
+              \\"requests\\": {
+                \\"cpu\\": \\"100m\\",
+                \\"memory\\": \\"100Mi\\"
+              }
+            },
+            \\"ports\\": [
+              {
+                \\"containerPort\\": 6379
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+});
+
+module.exports = [deployment, service, deployment1];"
+`;
+
+exports[`when path is a file should print the output 1`] = `
+"\\"use strict\\";
+
+const { Deployment } = require(\\"kubernetes-models/apps/v1/Deployment\\");
+
+const deployment = new Deployment({
+  \\"metadata\\": {
+    \\"name\\": \\"redis-master\\",
+    \\"labels\\": {
+      \\"app\\": \\"redis\\"
+    }
+  },
+  \\"spec\\": {
+    \\"selector\\": {
+      \\"matchLabels\\": {
+        \\"app\\": \\"redis\\",
+        \\"role\\": \\"master\\",
+        \\"tier\\": \\"backend\\"
+      }
+    },
+    \\"replicas\\": 1,
+    \\"template\\": {
+      \\"metadata\\": {
+        \\"labels\\": {
+          \\"app\\": \\"redis\\",
+          \\"role\\": \\"master\\",
+          \\"tier\\": \\"backend\\"
+        }
+      },
+      \\"spec\\": {
+        \\"containers\\": [
+          {
+            \\"name\\": \\"master\\",
+            \\"image\\": \\"k8s.gcr.io/redis:e2e\\",
+            \\"resources\\": {
+              \\"requests\\": {
+                \\"cpu\\": \\"100m\\",
+                \\"memory\\": \\"100Mi\\"
+              }
+            },
+            \\"ports\\": [
+              {
+                \\"containerPort\\": 6379
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+});
+
+module.exports = [deployment];"
+`;

--- a/integration/kosko-migrate/__tests__/index.ts
+++ b/integration/kosko-migrate/__tests__/index.ts
@@ -1,0 +1,81 @@
+import execa from "execa";
+import { runCLI } from "../../run";
+import { join } from "path";
+import fs from "fs";
+import { promisify } from "util";
+
+const fixtureDir = join(__dirname, "..", "__fixtures__");
+const readFile = promisify(fs.readFile);
+
+let args: string[];
+let result: execa.ExecaReturns;
+let options: execa.Options;
+
+beforeEach(async () => {
+  result = await runCLI(args, {
+    ...options,
+    cwd: fixtureDir
+  });
+});
+
+describe("when filename is not given", () => {
+  beforeAll(() => {
+    args = ["migrate"];
+    options = { reject: false };
+  });
+
+  test("should return status code 1", () => {
+    expect(result.code).toEqual(1);
+  });
+
+  test("should print the error", () => {
+    expect(result.stderr).toMatchSnapshot();
+  });
+});
+
+describe("when path is -", () => {
+  beforeAll(async () => {
+    args = ["migrate", "-f", "-"];
+    options = {
+      input: await readFile(join(fixtureDir, "only-deployment.yaml"))
+    };
+  });
+
+  test("should return status code 0", () => {
+    expect(result.code).toEqual(0);
+  });
+
+  test("should print the output", () => {
+    expect(result.stdout).toMatchSnapshot();
+  });
+});
+
+describe("when path is a file", () => {
+  beforeAll(() => {
+    args = ["migrate", "-f", "only-deployment.yaml"];
+    options = {};
+  });
+
+  test("should return status code 0", () => {
+    expect(result.code).toEqual(0);
+  });
+
+  test("should print the output", () => {
+    expect(result.stdout).toMatchSnapshot();
+  });
+});
+
+describe("when path is a directory", () => {
+  beforeAll(() => {
+    args = ["migrate", "-f", fixtureDir];
+    options = {};
+  });
+
+  test("should return status code 0", () => {
+    expect(result.code).toEqual(0);
+  });
+
+  test("should print the output", () => {
+    expect(result.stdout).toMatchSnapshot();
+  });
+});

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kosko/cli",
-	"version": "0.8.2",
+	"version": "0.8.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -62,9 +62,9 @@
 			}
 		},
 		"@types/yargs": {
-			"version": "12.0.9",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.9.tgz",
-			"integrity": "sha512-sCZy4SxP9rN2w30Hlmg5dtdRwgYQfYRiLo9usw8X9cxlf+H4FqM1xX7+sNH7NNKVdbXMJWqva7iyy+fxh/V7fA==",
+			"version": "12.0.10",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.10.tgz",
+			"integrity": "sha512-WsVzTPshvCSbHThUduGGxbmnwcpkgSctHGHTqzWyFg4lYAuV5qXlyFPOsP3OWqCINfmg/8VXP+zJaa4OxEsBQQ==",
 			"dev": true
 		},
 		"ansi-regex": {
@@ -226,19 +226,9 @@
 			}
 		},
 		"get-caller-file": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.4.tgz",
-			"integrity": "sha512-asZ7znBEyqkVHAjMI14GLeskxIJjn1Gplsvh1neaiHXgqRasKDR4uFnkMQXLMb7+0wn221u5vdY6QBkhgxkx0Q==",
-			"requires": {
-				"@types/node": "^11.10.5"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "11.11.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.0.tgz",
-					"integrity": "sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg=="
-				}
-			}
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
 		},
 		"get-stdin": {
 			"version": "6.0.0",
@@ -355,19 +345,19 @@
 			}
 		},
 		"mem": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
-			"integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
+			"integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
 			"requires": {
 				"map-age-cleaner": "^0.1.1",
-				"mimic-fn": "^1.0.0",
+				"mimic-fn": "^2.0.0",
 				"p-is-promise": "^2.0.0"
 			}
 		},
 		"mimic-fn": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
+			"integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA=="
 		},
 		"ms": {
 			"version": "2.1.1",
@@ -613,9 +603,9 @@
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 				},
 				"strip-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
-					"integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"requires": {
 						"ansi-regex": "^4.1.0"
 					}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,6 +52,6 @@
     "@types/exit": "^0.1.30",
     "@types/get-stdin": "^5.0.1",
     "@types/signale": "^1.2.1",
-    "@types/yargs": "^12.0.9"
+    "@types/yargs": "^12.0.10"
   }
 }


### PR DESCRIPTION
Don't set the type of filename option to `array` because yargs can't parse `kosko migrate -f -` properly.

Fix #17 