### PR TITLE
Add "baseEnvironment" option to config

### DIFF
--- a/integration/kosko-generate/validation-error/__tests__/index.ts
+++ b/integration/kosko-generate/validation-error/__tests__/index.ts
@@ -1,12 +1,16 @@
 import execa from "execa";
 import { dirname } from "path";
-import { runCLI } from "../../../run";
+import { runCLI, installPackage } from "../../../run";
 
 const testDir = dirname(__dirname);
 
 let args: string[];
 let result: execa.ExecaReturnValue;
 let options: execa.Options;
+
+beforeAll(async () => {
+  await installPackage(testDir, "env");
+});
 
 beforeEach(async () => {
   result = await runCLI(args, {

--- a/integration/kosko-generate/with-require/__tests__/index.ts
+++ b/integration/kosko-generate/with-require/__tests__/index.ts
@@ -1,12 +1,17 @@
 import execa from "execa";
 import { dirname } from "path";
-import { runCLI } from "../../../run";
+import { runCLI, installPackage } from "../../../run";
 
+const testDir = dirname(__dirname);
 let result: execa.ExecaReturnValue;
+
+beforeAll(async () => {
+  await installPackage(testDir, "env");
+});
 
 beforeEach(async () => {
   result = await runCLI(["generate"], {
-    cwd: dirname(__dirname)
+    cwd: testDir
   });
 });
 

--- a/integration/kosko-generate/without-require/__tests__/index.ts
+++ b/integration/kosko-generate/without-require/__tests__/index.ts
@@ -1,8 +1,6 @@
 import execa from "execa";
-import { dirname, join } from "path";
-import { runCLI } from "../../../run";
-import symlinkDir from "symlink-dir";
-import pkgDir from "pkg-dir";
+import { dirname } from "path";
+import { runCLI, installPackage } from "../../../run";
 
 const testDir = dirname(__dirname);
 
@@ -11,12 +9,7 @@ let result: execa.ExecaReturnValue;
 let options: execa.Options;
 
 beforeAll(async () => {
-  const root = await pkgDir();
-
-  await symlinkDir(
-    join(root!, "packages", "env"),
-    join(testDir, "node_modules", "@kosko", "env")
-  );
+  await installPackage(testDir, "env");
 });
 
 beforeEach(async () => {
@@ -105,7 +98,7 @@ describe("when key in the set argument is invalid", () => {
       "--env",
       "dev",
       "--set.nginx",
-      "tolerations[?@.key=='key2'].value=newValue",
+      "tolerations[?@.key=='key2'].value=newValue"
     ];
     options = { reject: false };
   });
@@ -126,7 +119,7 @@ describe("when value in the set argument is invalid", () => {
       "--env",
       "dev",
       "--set.nginx",
-      "image.registry nginx.io",
+      "image.registry nginx.io"
     ];
     options = { reject: false };
   });
@@ -142,13 +135,7 @@ describe("when value in the set argument is invalid", () => {
 
 describe("when nested value in the set argument is invalid", () => {
   beforeAll(() => {
-    args = [
-      "generate",
-      "--env",
-      "dev",
-      "--set.nginx",
-      "3",
-    ];
+    args = ["generate", "--env", "dev", "--set.nginx", "3"];
     options = { reject: false };
   });
 

--- a/integration/kosko-template/__tests__/index.ts
+++ b/integration/kosko-template/__tests__/index.ts
@@ -1,11 +1,10 @@
 import execa from "execa";
 import fs from "fs";
 import { join } from "path";
-import pkgDir from "pkg-dir";
-import symlinkDir from "symlink-dir";
 import tempDir from "temp-dir";
 import tmp from "tmp-promise";
 import { promisify } from "util";
+import { installPackage } from "../../run";
 
 const copyFile = promisify(fs.copyFile);
 const readFile = promisify(fs.readFile);
@@ -16,17 +15,12 @@ let options: execa.Options;
 let tmpDir: tmp.DirectoryResult;
 
 beforeEach(async () => {
-  const root = await pkgDir();
   tmpDir = await tmp.dir({ dir: tempDir, unsafeCleanup: true });
 
   const src = join(__dirname, "..", "bin.js");
   const dst = join(tmpDir.path, "bin.js");
   await copyFile(src, dst);
-
-  await symlinkDir(
-    join(root!, "packages", "template"),
-    join(tmpDir.path, "node_modules", "@kosko", "template")
-  );
+  await installPackage(tmpDir.path, "template");
 
   result = await execa(dst, args, {
     ...options,

--- a/integration/kosko-validate/failed/__tests__/index.ts
+++ b/integration/kosko-validate/failed/__tests__/index.ts
@@ -1,10 +1,14 @@
 import execa from "execa";
 import { dirname } from "path";
-import { runCLI } from "../../../run";
+import { runCLI, installPackage } from "../../../run";
 
 const testDir = dirname(__dirname);
 
 let result: execa.ExecaReturnValue;
+
+beforeAll(async () => {
+  await installPackage(testDir, "env");
+});
 
 beforeEach(async () => {
   result = await runCLI(["validate"], {

--- a/integration/kosko-validate/passed/__tests__/index.ts
+++ b/integration/kosko-validate/passed/__tests__/index.ts
@@ -1,10 +1,14 @@
 import execa from "execa";
 import { dirname } from "path";
-import { runCLI } from "../../../run";
+import { runCLI, installPackage } from "../../../run";
 
 const testDir = dirname(__dirname);
 
 let result: execa.ExecaReturnValue;
+
+beforeAll(async () => {
+  await installPackage(testDir, "env");
+});
 
 beforeEach(async () => {
   result = await runCLI(["validate"], {

--- a/integration/run.ts
+++ b/integration/run.ts
@@ -1,19 +1,28 @@
 import execa from "execa";
-import pkgDir from "pkg-dir";
-import { join } from "path";
+import { join, dirname } from "path";
+import symlinkDir from "symlink-dir";
+
+const root = dirname(__dirname);
 
 export async function runCLI(
   args: string[],
   options: execa.Options = {}
 ): Promise<execa.ExecaReturnValue> {
-  const root = await pkgDir();
-
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return execa(join(root!, "packages", "cli", "bin", "kosko.js"), args, {
+  return execa(join(root, "packages", "cli", "bin", "kosko.js"), args, {
     ...options,
     env: {
       LC_ALL: "en_US",
       ...options.env
     }
   });
+}
+
+export async function installPackage(
+  path: string,
+  name: string
+): Promise<void> {
+  await symlinkDir(
+    join(root, "packages", name),
+    join(path, "node_modules", "@kosko", name)
+  );
 }

--- a/packages/config/src/__fixtures__/toml/kosko.toml
+++ b/packages/config/src/__fixtures__/toml/kosko.toml
@@ -2,6 +2,8 @@ require = ["a"]
 components = ["b", "c"]
 extensions = ["js", "json"]
 
+baseEnvironment = "m"
+
 [environments.dev]
 require = ["d", "e"]
 components = ["f", "g"]

--- a/packages/config/src/__tests__/__snapshots__/config.ts.snap
+++ b/packages/config/src/__tests__/__snapshots__/config.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`loadConfig when file exists should load the config 1`] = `
 Object {
+  "baseEnvironment": "m",
   "components": Array [
     "b",
     "c",
@@ -45,6 +46,7 @@ Object {
 
 exports[`searchConfig succeed when config is at kosko.toml should load the config 1`] = `
 Object {
+  "baseEnvironment": "m",
   "components": Array [
     "b",
     "c",

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -23,4 +23,7 @@ export interface Config extends EnvironmentConfig {
 
   /** File extensions of components. */
   readonly extensions?: ReadonlyArray<string>;
+
+  /** Base environment. */
+  readonly baseEnvironment?: string;
 }

--- a/packages/env/src/__fixtures__/environments/base/foo.js
+++ b/packages/env/src/__fixtures__/environments/base/foo.js
@@ -1,0 +1,1 @@
+module.exports = { b: __filename };

--- a/packages/env/src/__fixtures__/environments/base/index.js
+++ b/packages/env/src/__fixtures__/environments/base/index.js
@@ -1,0 +1,1 @@
+module.exports = { a: __filename };

--- a/packages/env/src/__tests__/environment.ts
+++ b/packages/env/src/__tests__/environment.ts
@@ -97,7 +97,7 @@ describe("when env is set", () => {
 
       test("should load from custom path", () => {
         expect(env.global()).toEqual(
-          require(join(fixturePath, "foo", env.env!))
+          require(join(fixturePath, "foo", env.env as string))
         );
       });
     });
@@ -109,7 +109,7 @@ describe("when env is set", () => {
 
       test("should load from custom path", () => {
         expect(env.component("bar")).toEqual(
-          require(join(fixturePath, "foo", "bar", env.env!))
+          require(join(fixturePath, "foo", "bar", env.env as string))
         );
       });
     });
@@ -183,6 +183,56 @@ describe("when env is set", () => {
       test("shold return global + component vars", () => {
         expect(env.component("foo")).toEqual(
           merge(require(envPath), require(join(envPath, "foo")))
+        );
+      });
+    });
+  });
+});
+
+describe("when env is an array", () => {
+  describe("and is empty", () => {
+    beforeEach(() => {
+      env.env = [];
+    });
+
+    describe("global", () => {
+      test("should return empty object", () => {
+        expect(env.global()).toEqual({});
+      });
+    });
+
+    describe("component", () => {
+      test("should return empty object", () => {
+        expect(env.component("foo")).toEqual({});
+      });
+    });
+  });
+
+  describe("and is not empty", () => {
+    let envPath: string;
+
+    beforeEach(() => {
+      env.env = ["base", "dev"];
+      envPath = join(fixturePath, "environments");
+    });
+
+    describe("global", () => {
+      test("should merge global vars of specified envs", () => {
+        expect(env.global()).toEqual(
+          merge(require(join(envPath, "base")), require(join(envPath, "dev")))
+        );
+      });
+    });
+
+    describe("component", () => {
+      test("should merge global + component vars of specified envs", () => {
+        expect(env.component("foo")).toEqual(
+          merge(
+            require(join(envPath, "base")),
+            require(join(envPath, "dev")),
+            require(join(envPath, "base", "foo")),
+            require(join(envPath, "dev", "foo"))
+          )
         );
       });
     });

--- a/packages/env/src/__tests__/paths.ts
+++ b/packages/env/src/__tests__/paths.ts
@@ -1,0 +1,7 @@
+import { formatPath } from "../paths";
+
+test("works", () => {
+  expect(formatPath("a/#{b}/c/#{d}", { b: "foo", d: "bar" })).toEqual(
+    "a/foo/c/bar"
+  );
+});

--- a/packages/env/src/environment.ts
+++ b/packages/env/src/environment.ts
@@ -42,7 +42,7 @@ export interface Reducer {
 export class Environment {
   private reducers: Reducer[] = [];
 
-  public env?: string;
+  public env?: string | string[];
   public paths: Paths = {
     global: "environments/#{environment}",
     component: "environments/#{environment}/#{component}"
@@ -98,7 +98,7 @@ export class Environment {
   private createGlobalReducer(): Reducer {
     const reducer: Reducer = {
       name: "global",
-      reduce: values => merge(values, this.require(this.paths.global))
+      reduce: values => merge(values, ...this.requireAllEnvs(this.paths.global))
     };
 
     return reducer;
@@ -108,28 +108,30 @@ export class Environment {
     const reducer: Reducer = {
       name: "component",
       reduce: (values, componentName) => {
-        if (componentName) {
-          return merge(
-            values,
-            this.require(this.paths.component, componentName)
-          );
-        }
+        if (!componentName) return values;
 
-        return values;
+        return merge(
+          values,
+          ...this.requireAllEnvs(this.paths.component, componentName)
+        );
       }
     };
 
     return reducer;
   }
 
-  private require(template: string, component?: string): any {
-    if (!this.env) return {};
+  private requireAllEnvs(template: string, component?: string): any[] {
+    if (!this.env) return [];
 
-    const path = formatPath(template, {
-      environment: this.env,
-      component
+    const envs = Array.isArray(this.env) ? this.env : [this.env];
+
+    return envs.map(env => {
+      const path = formatPath(template, {
+        environment: env,
+        component
+      });
+
+      return tryRequire(join(this.cwd, path));
     });
-
-    return tryRequire(join(this.cwd, path));
   }
 }

--- a/packages/env/src/environment.ts
+++ b/packages/env/src/environment.ts
@@ -2,9 +2,9 @@ import { join } from "path";
 import { requireDefault } from "@kosko/require";
 import Debug from "debug";
 import { merge } from "./merge";
+import { Paths, formatPath } from "./paths";
 
 const debug = Debug("kosko:env");
-const rTemplate = /#\{(\w+)\}/g;
 
 function tryRequire(id: string): any {
   try {
@@ -17,11 +17,6 @@ function tryRequire(id: string): any {
 
     throw err;
   }
-}
-
-export interface Paths {
-  global: string;
-  component: string;
 }
 
 /**
@@ -123,20 +118,16 @@ export class Environment {
         return values;
       }
     };
-    
+
     return reducer;
   }
 
   private require(template: string, component?: string): any {
     if (!this.env) return {};
 
-    const data: any = {
+    const path = formatPath(template, {
       environment: this.env,
       component
-    };
-
-    const path = template.replace(rTemplate, (s, key) => {
-      return data[key];
     });
 
     return tryRequire(join(this.cwd, path));

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,7 +1,8 @@
-import { Environment, Paths, Reducer } from "./environment";
+import { Environment, Reducer } from "./environment";
 
 export default new Environment(process.cwd());
-export { Environment, Paths, Reducer };
+export { Environment, Reducer };
+export { Paths } from "./paths";
 
 // HACK: Export default to module.exports and maintain types above.
 module.exports = Object.assign(exports.default, exports);

--- a/packages/env/src/paths.ts
+++ b/packages/env/src/paths.ts
@@ -1,0 +1,12 @@
+const rTemplate = /#\{(\w+)\}/g;
+
+export interface Paths {
+  global: string;
+  component: string;
+}
+
+export function formatPath(path: string, data: any): string {
+  return path.replace(rTemplate, (s, key) => {
+    return data[key];
+  });
+}


### PR DESCRIPTION
## Changes

- **config**: You can set `baseEnvironment` in `kosko.toml` to specify the base environment. The base environment contains default or common variables and can be overrided with `-e/--env` argument.
- **cli**: `@kosko/env` is required to be installed when running `kosko generate` or `kosko validate` even if you don't use it.
- **env**: `env` can be set to a string or an array of strings. Variables of environments in the `env` array are merged.

Close #18 
